### PR TITLE
Feat:  선호도조사 - 랜덤 음악 추출 API 

### DIFF
--- a/musics/urls.py
+++ b/musics/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path('<int:music_id>/reviews/<int:review_id>/', views.ReviewDetailView.as_view(), name='review_detail_view'),
     path('', views.MusicView.as_view(), name='music_view'),
     path('<int:music_id>/', views.MusicDetailView.as_view(), name='music_detail_view'),
+    path('random/', views.MusicRandomView.as_view(), name='music_random_view'),
 ]

--- a/musics/views.py
+++ b/musics/views.py
@@ -1,3 +1,4 @@
+import random
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework import status
@@ -7,6 +8,7 @@ from musics.serializers import ReviewSerializer,ReviewCreateSerializer,MusicSeri
 from musics.recommend import recommend_musics, recommend_users, music_grades_merge, collaborative_filtering
 from users.models import User
 from users.serializers import RecommendUserSerializer
+from django.db.models import Max 
 
 from musics.dummy import grade_to_csv
 # Create your views here.
@@ -111,3 +113,19 @@ class MusicDetailView(APIView):
         music = get_object_or_404(Music, id=music_id)
         music.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class MusicRandomView(APIView):
+    def get(self, request):
+        # random 제한 수가 없으면 default: 20 개로 랜덤 music 목록 출력
+        limit = request.data.get("limit",20)
+        print(limit)
+        max_id = Music.objects.aggregate(max_id=Max('id'))['max_id']
+        musit_random_list = []
+        while len(musit_random_list) < limit:
+            random_index = random.randint(1, max_id)
+            music = Music.objects.get(id=random_index)
+            if music:
+                serializer = MusicSerializer(music)
+                musit_random_list.append(serializer.data)
+        return Response(musit_random_list, status=status.HTTP_200_OK)


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/37-musicRandom -> main

## 변경 사항
1. 선호도 조사에 필요한 랜덤 음악 추출 API 구현
	- URL : GET '/music/random/'
	- request.data = {"limit": 추출개수}
	- limit 전달 없으면 default: 20
	- response.data = 랜덤으로 limit 수 만큼 추출된 Music모델

## 테스트 결과
변경 사항을 설명하는데 도움이 되는 스크린샷이나 참고 자료를 추가해주세요.
**limit 전달시**
<img width="1085" alt="Screen Shot 2022-11-05 at 8 47 54 PM" src="https://user-images.githubusercontent.com/12287842/200118405-492a100c-3483-41ca-a4a2-7e4094874c4b.png">

**limit 미 전달시 : 20개**
<img width="1084" alt="Screen Shot 2022-11-05 at 8 48 07 PM" src="https://user-images.githubusercontent.com/12287842/200118444-d5ffdef9-36c3-4571-8ec2-3bf3047684b0.png">
