### PR TITLE
Feat: 전체음원 조회 API 구현

### DIFF
--- a/musics/urls.py
+++ b/musics/urls.py
@@ -5,6 +5,7 @@ urlpatterns = [
     path('<int:music_id>/reviews/', views.ReviewView.as_view(), name='review_view'),
     path('<int:music_id>/reviews/<int:review_id>/', views.ReviewDetailView.as_view(), name='review_detail_view'),
     path('', views.MusicView.as_view(), name='music_view'),
+    path('recommend/', views.MusicRecommandView.as_view(), name='music_recommend_view'),
     path('<int:music_id>/', views.MusicDetailView.as_view(), name='music_detail_view'),
     path('random/', views.MusicRandomView.as_view(), name='music_random_view'),
 ]

--- a/musics/views.py
+++ b/musics/views.py
@@ -61,7 +61,7 @@ class ReviewDetailView(APIView):
                 return Response("권한이 없습니다!", status=status.HTTP_403_FORBIDDEN)
 
 
-class MusicView(APIView):
+class MusicRecommandView(APIView):
     def get(self, request):
         musics = Music.objects.all()[:11]
         serializer = MusicSerializer(musics, many=True)
@@ -83,7 +83,12 @@ class MusicView(APIView):
         }
         return Response(context, status=status.HTTP_200_OK)
 
-    
+class MusicView(APIView):
+    def get(self, request):
+        musics = Music.objects.all().order_by("-id") # 최신순 정렬
+        serializer = MusicSerializer(musics, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
     def post(self, request):
         serializer = MusicCreateSerializer(data=request.data)
         if serializer.is_valid():


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/41-allMusicAPI -> main

## 변경 사항
1. 기존 URL("/musics/")을 사용하고 있던 추천음악/추천유저 목록 API 분리#42 
    - URL 변경 : '/musics/' -> '/musics/recommend/' 
    - views.py 클래스 변경 : MusicView -> MusicRecommandView

2. 음악 전체 조회API 작업
       - URL : '/musics/'
       - Requset: X
       - Response : 최신순으로 정렬된 music 전체 목록


## 테스트 결과
변경 사항을 설명하는데 도움이 되는 스크린샷이나 참고 자료를 추가해주세요.
전체 음악 목록 조회(최신순)
<img width="1086" alt="Screen Shot 2022-11-06 at 1 40 13 PM" src="https://user-images.githubusercontent.com/12287842/200154571-b9a33cfa-3113-4bd6-8ee3-1236924d6c96.png">

변경된 추천음악/추천유저/top200 목록 'musics/' -> /musics/recommend'
<img width="1085" alt="Screen Shot 2022-11-06 at 1 40 44 PM" src="https://user-images.githubusercontent.com/12287842/200154598-5794753e-8a42-48ca-90d8-c59cc6c4096c.png">
<img width="1081" alt="Screen Shot 2022-11-06 at 1 40 58 PM" src="https://user-images.githubusercontent.com/12287842/200154602-d21061eb-ad60-48b1-81fc-ddef9d8152b0.png">
<img width="1085" alt="Screen Shot 2022-11-06 at 1 41 08 PM" src="https://user-images.githubusercontent.com/12287842/200154604-2f845d53-bfea-4a6e-b0e7-3d2057f4583a.png">
