### PR TITLE
Refactor: Review API 리뉴얼

### DIFF
--- a/musics/serializers.py
+++ b/musics/serializers.py
@@ -26,6 +26,10 @@ class ReviewSerializer(serializers.ModelSerializer):
 
 
 class ReviewCreateSerializer(serializers.ModelSerializer):
+    user = serializers.SerializerMethodField()
+    def get_user(self, obj):
+        return obj.user.username
+
     class Meta:
         model = Review
         fields = '__all__'

--- a/musics/urls.py
+++ b/musics/urls.py
@@ -3,7 +3,7 @@ from musics import views
 
 urlpatterns = [
     path('<int:music_id>/reviews/', views.ReviewView.as_view(), name='review_view'),
-    path('<int:music_id>/reviews/<int:review_id>/', views.ReviewDetailView.as_view(), name='review_detail_view'),
+    path('reviews/<int:review_id>/', views.ReviewDetailView.as_view(), name='review_detail_view'),
     path('', views.MusicView.as_view(), name='music_view'),
     path('recommend/', views.MusicRecommandView.as_view(), name='music_recommend_view'),
     path('<int:music_id>/', views.MusicDetailView.as_view(), name='music_detail_view'),

--- a/musics/views.py
+++ b/musics/views.py
@@ -20,7 +20,7 @@ class ReviewView(APIView):
         reviews = musics.reviews.all()
         for review in reviews:
             if review.user==request.user:
-                return Response({'message':'이미 작성 하였습니다!'})
+                return Response({'message':'이미 작성 하였습니다!'}, status=status.HTTP_400_BAD_REQUEST)
 
         serializer = ReviewCreateSerializer(data=request.data)
         if serializer.is_valid():
@@ -40,7 +40,7 @@ class ReviewView(APIView):
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 class ReviewDetailView(APIView):
-    def put(self, request, music_id, review_id): 
+    def put(self, request, review_id): 
         review = get_object_or_404(Review, id=review_id)
         if request.user == review.user:
             serializer = ReviewUpdateSerializer(review, data=request.data)
@@ -50,15 +50,15 @@ class ReviewDetailView(APIView):
             else:
                 return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         else:
-            return Response("권한이 없습니다!", status=status.HTTP_403_FORBIDDEN)
+            return Response({"messages": "권한이 없습니다!"}, status=status.HTTP_403_FORBIDDEN)
         
-    def delete(self, request, music_id, review_id): 
+    def delete(self, request, review_id): 
             review = get_object_or_404(Review, id=review_id)
             if request.user == review.user:
                 review.delete()
-                return Response(status=status.HTTP_204_NO_CONTENT)
+                return Response({"messages": "삭제 되었습니다."}, status=status.HTTP_204_NO_CONTENT)
             else:
-                return Response("권한이 없습니다!", status=status.HTTP_403_FORBIDDEN)
+                return Response({"messages": "권한이 없습니다!"}, status=status.HTTP_403_FORBIDDEN)
 
 
 class MusicRecommandView(APIView):


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/0-renewalReviewAPI -> main

## 변경 사항
1. review API 중 수정,삭제에서 music_id를 받아오지만 사용하지 않는걸로 판단.
2. 변경된 review API 경로
	- 리뷰수정 : PUT 'music/review/<int:review_id'>
	- 리뷰삭제 : Delete 'music/reveiw/<int:review_id'>
3. ReviewCreateSerializer에서 user필드는 user.username으로 나오게 지정.
4. return시 Response 응답 json으로 전달.


## 테스트 결과
변경된 리뷰 수정 URL  PUT 'music/review/<int:review_id'>
<img width="1093" alt="Screen Shot 2022-11-07 at 4 21 50 PM" src="https://user-images.githubusercontent.com/12287842/200248711-feb60b7c-d278-4c7d-ac51-bd1819288541.png">


변경된 리뷰 삭제 URL  Delete 'music/review/<int:review_id'>
<img width="1085" alt="Screen Shot 2022-11-07 at 4 18 58 PM" src="https://user-images.githubusercontent.com/12287842/200248123-94eb7645-7339-4022-b702-1b939b69a8d6.png">

