### PR TITLE
Rename: 로그인페이지에 대한 url, view 이름만 변경 #50

### DIFF
--- a/users/urls.py
+++ b/users/urls.py
@@ -8,7 +8,7 @@ from rest_framework_simplejwt.views import (
 
 urlpatterns = [
     path('signup/', views.UserView.as_view(), name='user_view'),
-    path('api/token/', views.CustomTokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('signin/', views.SigninView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('logout/', views.LogoutView.as_view(), name="logout"),
     path('follow/<int:user_id>/', views.FollowView.as_view(), name='follow_view'),

--- a/users/views.py
+++ b/users/views.py
@@ -25,9 +25,9 @@ class UserView(APIView):
         else:
             return Response({"message":f"${serializer.errors}"}, status=status.HTTP_400_BAD_REQUEST)          
 
-class CustomTokenObtainPairView(TokenObtainPairView):
-    serializer_class = CustomTokenObtainPairSerializer
-
+class SigninView(TokenObtainPairView):
+    serializer = CustomTokenObtainPairSerializer
+        
 class LogoutView(APIView):
     serializer = LogoutSerializer
     


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/50-signin_rename> -> main

## 변경 사항
1. 로그인페이지에 대한 url, view 이름만 변경
    - [ ] url: /users/api/token/ => /users/signin/ 
    - [ ] [세부기능2-1](view: CustomTokenObtainPairView => SigninView)

## 테스트 결과
변경 사항을 설명하는데 도움이 되는 스크린샷이나 참고 자료를 추가해주세요.